### PR TITLE
fix: resolve @hono-telescope/types import errors

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,6 @@
 import { telescope } from './middleware/telescope-middleware';
 import { TelescopeRoutes } from './routes/telescope-routes';
-import { TelescopeConfig } from '@hono-telescope/types';
+import { TelescopeConfig } from '@/types';
 import { startExceptionWatcher } from './watchers/exception-watcher';
 import { startLogWatcher } from './watchers/log-watcher';
 import { startQueryWatcher } from './watchers/query-watcher';

--- a/src/core/middleware/telescope-middleware.ts
+++ b/src/core/middleware/telescope-middleware.ts
@@ -1,6 +1,6 @@
 import type { Context, Next, MiddlewareHandler } from 'hono';
 import { Telescope } from '../telescope';
-import { TelescopeConfig } from '@hono-telescope/types';
+import { TelescopeConfig } from '@/types';
 import { ContextManager } from '../context-manager';
 import { HttpInterceptor } from '../interceptors/http-interceptor';
 import { DatabaseInterceptor } from '../interceptors/database-interceptor';

--- a/src/core/storage/memory-storage.ts
+++ b/src/core/storage/memory-storage.ts
@@ -5,7 +5,7 @@ import {
   ExceptionEntry,
   LogEntry,
   QueryEntry,
-} from '@hono-telescope/types';
+} from '@/types';
 import { find, filter } from 'lodash';
 
 class BaseRepository<T extends BaseEntry> {

--- a/src/core/telescope.ts
+++ b/src/core/telescope.ts
@@ -12,7 +12,7 @@ import {
   QueryCreateInput,
   TelescopeCreateInput,
   BaseEntry,
-} from '@hono-telescope/types';
+} from '@/types';
 import { MemoryStorage } from './storage/memory-storage';
 
 export class Telescope {

--- a/src/core/utils/helpers.ts
+++ b/src/core/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { ExceptionClass } from '@hono-telescope/types';
+import { ExceptionClass } from '@/types';
 
 export const getExceptionClassCode = (errorName: string): number => {
   switch (errorName) {

--- a/src/core/utils/mappers.ts
+++ b/src/core/utils/mappers.ts
@@ -9,7 +9,7 @@ import type {
   ExceptionResponse,
   LogResponse,
   QueryResponse,
-} from '@hono-telescope/types';
+} from '@/types';
 
 export const mapIncomingRequest = (e: IncomingRequestEntry): IncomingRequestResponse => ({
   id: e.id,

--- a/src/core/watchers/log-watcher.ts
+++ b/src/core/watchers/log-watcher.ts
@@ -1,5 +1,5 @@
 import { Telescope } from '../telescope';
-import { LogLevel } from '@hono-telescope/types';
+import { LogLevel } from '@/types';
 import { ContextManager } from '../context-manager';
 import { isObject, map } from 'lodash';
 

--- a/src/dashboard/api/telescopeApi.ts
+++ b/src/dashboard/api/telescopeApi.ts
@@ -11,7 +11,7 @@ import {
   QueryDetailResponse,
   LogResponse,
   LogDetailResponse,
-} from '@hono-telescope/types';
+} from '@/types';
 
 export const telescopeApi = createApi({
   reducerPath: 'telescopeApi',

--- a/src/dashboard/components/Table/ExceptionTable.tsx
+++ b/src/dashboard/components/Table/ExceptionTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ExceptionResponse } from '@hono-telescope/types';
+import { ExceptionResponse } from '@/types';
 import { formatDate } from '../../utils/helpers';
 import ExceptionTag from '../Tag/ExceptionTag';
 import Table from './Table';

--- a/src/dashboard/components/Table/IncomingRequestTable.tsx
+++ b/src/dashboard/components/Table/IncomingRequestTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { formatDate } from '../../utils/helpers';
-import { IncomingRequestResponse } from '@hono-telescope/types';
+import { IncomingRequestResponse } from '@/types';
 import MethodTag from '../Tag/MethodTag';
 import StatusTag from '../Tag/StatusTag';
 import DurationTag from '../Tag/DurationTag';

--- a/src/dashboard/components/Table/LogTable.tsx
+++ b/src/dashboard/components/Table/LogTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { formatDate } from '../../utils/helpers';
-import { LogResponse } from '@hono-telescope/types';
+import { LogResponse } from '@/types';
 import LevelTag from '../Tag/LevelTag';
 import Table from './Table';
 

--- a/src/dashboard/components/Table/OutgoingRequestTable.tsx
+++ b/src/dashboard/components/Table/OutgoingRequestTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { formatDate } from '../../utils/helpers';
-import { OutgoingRequestResponse } from '@hono-telescope/types';
+import { OutgoingRequestResponse } from '@/types';
 import DurationTag from '../Tag/DurationTag';
 import StatusTag from '../Tag/StatusTag';
 import MethodTag from '../Tag/MethodTag';

--- a/src/dashboard/components/Table/QueryTable.tsx
+++ b/src/dashboard/components/Table/QueryTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { formatDate } from '../../utils/helpers';
-import { QueryResponse } from '@hono-telescope/types';
+import { QueryResponse } from '@/types';
 import DurationTag from '../Tag/DurationTag';
 import Table from './Table';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,6 @@
     "paths": {
       "@/*": ["src/*"],
       "@types/*": ["src/types/*"],
-      "@hono-telescope/types": ["src/types/index.ts"],
-      "@hono-telescope/types/*": ["src/types/*"],
       "@core/*": ["src/core/*"],
       "@dashboard/*": ["src/dashboard/*"]
     }


### PR DESCRIPTION
- Replace @hono-telescope/types imports with relative/alias paths
- Update import paths in core utilities and components
- Verify build succeeds with all changes

Fixes #1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace all @hono-telescope/types imports with '@/types' and remove related path aliases in tsconfig to resolve import issues.
> 
> - **Types/Imports**:
>   - Replace `@hono-telescope/types` imports with `@/types` across core (`index`, middleware, storage, telescope, utils, watchers) and dashboard (API, table components).
> - **Config**:
>   - Remove `@hono-telescope/types` path aliases from `tsconfig.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74ea8e30b8851c729b59fee68a53e3283e0a7b25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->